### PR TITLE
fix: Make #2 actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,45 @@ own repo so they can be used with `gatsby new`.
 
 ## Usage
 
-```tf
-workflow "Update starters" {
-  on = "push"
-  resolves = ["johno/actions-push-subdirectories"]
-  args = "examples"
+```yml
+name: Publish Starters
+on: push
+jobs:
+  master:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: publish:starters
+        uses: johno/actions-push-subdirectories@master
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: examples johno
+```
+
+The `GITHUB_TOKEN` will automatically be defined, the `API_TOKEN_GITHUB` needs to be set in the `Secrets` section of your repository options. You can retrieve the `API_TOKEN_GITHUB` [here](https://github.com/settings/tokens) (set the `repo` permission).
+
+The action accepts three arguments - the first two are mandatory, the third is optional.
+
+1. Name of the folder that contains your examples. Even if you only have one example currently it also should be placed inside its own folder (e.g. `examples/foo-bar`) as the script will read all folders inside the examples.
+2. GitHub username
+3. Repository name of the respective example. By default the `name` key from the example's `package.json` is used, e.g. the `name` of your example is `gatsby-starter-foobar`, then the script will try to push to `github.com/USERNAME/gatsby-starter-foobar`.
+
+### Custom starter names
+
+You could define the key `starter-name` in your example's `package.json`, like:
+
+```json
+{
+  "starter-name": "gatsby-starter-custom-foobar",
 }
+```
+
+Use the action with the third argument now:
+
+```yml
+args: examples johno starter-name
 ```
 
 ## Related

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 FOLDER=$1
 GITHUB_USERNAME=$2
-STARTER_NAME="${3:-'.name'}"
+STARTER_NAME="${3:-'name'}"
 BASE=$(pwd)
 
 git config --global user.email "johno-actions-push-subdirectories@example.org"
@@ -16,7 +16,7 @@ for folder in $FOLDER/*; do
 
   echo "Pushing $folder"
 
-  NAME=$(cat $folder/package.json | jq -r "$STARTER_NAME")
+  NAME=$(cat $folder/package.json | jq --arg name "$STARTER_NAME" -r '.[$name]')
   CLONE_DIR="__${NAME}__clone__"
 
   # clone, delete files in the clone, and copy (new) files over


### PR DESCRIPTION
Yeah, #2 didn't work, so here's the fix for that + README update.

TIL `jq` had a `--arg` flag. Before that I had some weird quotation mark errors.