### PR TITLE
(docs): Add an example of how to pass an empty third argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Using the action to push to `master` branch:
 args: examples johno starter-name master
 ```
 
+Using the action without a third argument by passing an empty string:
+
+```yml
+args: examples johno "" master
+```
+
 ## Related
 
 This code is adapted and modified from [Gatsby core](https://github.com/gatsbyjs/gatsby/blob/8933ca9b3bf2c9b4fd580dd437d8695c3be705b7/scripts/clone-and-validate.sh).


### PR DESCRIPTION
I found it difficult to figure out how to pass an empty third argument, I had to change back to `master` branch for how I am using this action. Figured it out by trial and error, didn't take long but might save others the trouble I had. 

I applaud the idea of defaulting to `main`! Keep it up!